### PR TITLE
Signal.SIGHUP error on non Linux OS

### DIFF
--- a/src/socket_log_receiver/config.py
+++ b/src/socket_log_receiver/config.py
@@ -1,6 +1,7 @@
 import logging
 import logging.handlers
 import signal
+import platform
 
 from resconfig import ResConfig
 
@@ -24,5 +25,7 @@ config = ResConfig(default, load_on_init=False)
 def handler(*args, **kwargs):
     config.load()
 
+if platform.system() != 'Linux':
+    signal.SIGHUP = 1
 
 signal.signal(signal.SIGHUP, handler)


### PR DESCRIPTION
Since python 3.7 signal.SIGHUP only works on Unix systems Add value manual to 1 in not linux os since the value of signal.SIGHUP on linux is 1

This solution base on https://stackoverflow.com/a/65906782